### PR TITLE
SAK-45131 - Default values for controls and autoplay to be booleans, not strings.

### DIFF
--- a/html5video/plugin.js
+++ b/html5video/plugin.js
@@ -22,9 +22,9 @@ CKEDITOR.plugins.add('html5video', {
       init() {
         const defaultConfig = {
           src : '',
-          autoplay : '',
+          autoplay : false,
           loop : '',
-          controls : '',
+          controls : true,
           align : this.element.getStyle('text-align'),
           width : '',
           height : '',


### PR DESCRIPTION
SAK-45131 - Changed default value to booleans. When you add a movie with the movie player, it just appears as a static image unless the "Show Controls" button or "Auto Play" features are selected. 